### PR TITLE
Remove free Wednesday and Friday parking

### DIFF
--- a/parking-meters-kiosk-locations/README.md
+++ b/parking-meters-kiosk-locations/README.md
@@ -32,6 +32,4 @@ Distinguishing Meters from Kiosks: manufacturer / model for kiosks - Parkeon Str
 
 ## Parking Amnesty Areas
 
-* Wednesdays are free after 5pm in Center City (Spring Garden-Bainbridge and Delaware to Schuylkill)
-* Fridays are the first Friday of the month after 5pm in Olde City (Front to 5th and Walnut to Callowhill)
 * Saturdays are free after 11am between Thanksgiving day and New years day. (Entire City)


### PR DESCRIPTION
This removes mention of free parking on Wednesdays and Fridays.

Source for rule change (effective October 2016):

 > http://www.philapark.org/2016/09/evening-parking-promotions-conclude-as-meterup-app-gains-in-popularity/